### PR TITLE
Controller flash messages moved into I18n

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,7 +7,7 @@ class ApplicationController < ActionController::Base
 
   def current_user_admin
     if !current_user.admin?
-      flash[:error] = "You are not permitted to view that page"
+      flash[:error] = I18n.t('controllers.application_controller.errors.current_user_admin')
       redirect_to root_path
     end
   end
@@ -43,7 +43,7 @@ class ApplicationController < ActionController::Base
 
   def authenticate_user!
     unless signed_in?
-      flash[:error] = "You need to sign in for access to this page."
+      flash[:error] = I18n.t('application_controller.errors.authenticate_user')
       redirect_to "/session/new"
     end
   end

--- a/app/controllers/auth_controller.rb
+++ b/app/controllers/auth_controller.rb
@@ -5,7 +5,7 @@ class AuthController < ApplicationController
     if team_member?
       user = User.find_or_create_by(email: auth_email)
       sign_in(user)
-      flash[:success] = "You successfully signed in"
+      flash[:success] = I18n.t('controllers.auth_controller.successes.oauth_callback')
       redirect_to root_path
     end
   end

--- a/app/controllers/employees_controller.rb
+++ b/app/controllers/employees_controller.rb
@@ -11,7 +11,7 @@ class EmployeesController < ApplicationController
 
 
     if @employee.errors.full_messages.empty? && @employee.save
-      flash[:notice] = "Thanks for adding #{@employee.slack_username}"
+      flash[:notice] = I18n.t('controllers.employees_controller.notices.create', slack_username: @employee.slack_username)
       redirect_to root_path
     else
       flash.now[:error] = @employee.errors.full_messages.to_sentence
@@ -39,7 +39,7 @@ class EmployeesController < ApplicationController
 
 
     if @employee.errors.full_messages.empty? && @employee.update(employee_params)
-      flash[:notice] = "Employee updated successfully"
+      flash[:notice] = I18n.t('controllers.employees_controller.notices.update')
       redirect_to employees_path
     else
       flash.now[:error] = @employee.errors.full_messages.to_sentence
@@ -51,7 +51,7 @@ class EmployeesController < ApplicationController
     @employee = Employee.find(params[:id])
     @employee.destroy
 
-    flash[:notice] = "You deleted #{@employee.slack_username}"
+    flash[:notice] = I18n.t('controllers.employees_controller.notices.destroy', slack_username: @employee.slack_username)
     redirect_to employees_path
   end
 

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -9,7 +9,7 @@ class MessagesController < ApplicationController
     @message = Message.new(message_params)
 
     if @message.save
-      flash[:notice] = "Message created successfully"
+      flash[:notice] = I18n.t('controllers.messages_controller.notices.create')
       redirect_to messages_path
     else
       flash.now[:error] = @message.errors.full_messages.join(", ")

--- a/app/controllers/scheduled_messages_controller.rb
+++ b/app/controllers/scheduled_messages_controller.rb
@@ -9,10 +9,10 @@ class ScheduledMessagesController < ApplicationController
     @scheduled_message = ScheduledMessage.new(scheduled_message_params)
 
     if @scheduled_message.save
-      flash[:notice] = "Scheduled message created successfully"
+      flash[:notice] = I18n.t('controllers.scheduled_messages_controller.notices.create')
       redirect_to root_path
     else
-      flash.now[:error] = "Could not create scheduled message"
+      flash.now[:error] = I18n.t('controllers.scheduled_messages_controller.errors.create')
       render action: :new
     end
   end
@@ -32,10 +32,10 @@ class ScheduledMessagesController < ApplicationController
     @scheduled_message = ScheduledMessage.find(params[:id])
 
     if @scheduled_message.update(scheduled_message_params)
-      flash[:notice] = "Scheduled message updated successfully"
+      flash[:notice] = I18n.t('controllers.scheduled_messages_controller.notices.update')
       redirect_to scheduled_messages_path
     else
-      flash.now[:error] = "Could not update scheduled message"
+      flash.now[:error] = I18n.t('controllers.scheduled_messages_controller.errors.update')
       render action: :edit
     end
   end
@@ -44,7 +44,7 @@ class ScheduledMessagesController < ApplicationController
     scheduled_message = ScheduledMessage.find(params[:id])
     scheduled_message.destroy
 
-    flash[:notice] = "You deleted #{scheduled_message.title}"
+    flash[:notice] = I18n.t('controllers.scheduled_messages_controller.notices.destroy', scheduled_message_title: scheduled_message.title)
     redirect_to scheduled_messages_path
   end
 

--- a/app/controllers/send_messages_controller.rb
+++ b/app/controllers/send_messages_controller.rb
@@ -5,7 +5,7 @@ class SendMessagesController < ApplicationController
     message = Message.find(params[:message_id])
     AllEmployeeMessageSender.new(message).run
 
-    flash[:notice] = "Message sent to all users"
+    flash[:notice] = I18n.t('controllers.send_messages_controller.notices.create')
     redirect_to messages_path
   end
 end

--- a/app/controllers/test_messages_controller.rb
+++ b/app/controllers/test_messages_controller.rb
@@ -14,11 +14,11 @@ class TestMessagesController < ApplicationController
 
     if employee && (employee.slack_channel_id || employee.slack_user_id)
       MessageSender.new(employee, message).delay.run
-      flash[:notice] = "Test message sent successfully"
+      flash[:notice] = I18n.t('controllers.test_messages_controller.notices.create')
     elsif employee.nil?
-      flash[:error] = "Oops! Looks like that employee isn't in the Dolores system yet! Make sure you've entered the Slack handle (#{slack_username}) for the employee before sending him/her/them a test message."
+      flash[:error] = I18n.t('controllers.test_messages_controller.errors.create.employee_nil', slack_username: slack_username)
     else
-      flash[:error] = "Oops! Looks like this employees information isn't up to date. Check to make sure they haven't changed their slackname!"
+      flash[:error] = I18n.t('controllers.test_messages_controller.errors.create.not_up_to_date')
     end
 
     redirect_to redirect_path

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -9,7 +9,7 @@ class UsersController < ApplicationController
     @user = User.find(params[:id])
 
     if @user.update(user_params)
-      flash[:notice] = "User updated successfully"
+      flash[:notice] = I18n.t('controllers.users_controller.notices.update')
       redirect_to employees_path
     end
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -68,9 +68,3 @@ en:
     users_controller:
       notices:
         update: "User updated successfully"
-
-
-
-
-
-

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -25,4 +25,52 @@ en:
       slack_username_in_org:
         "There is not a Slack user with the username \"%{slack_username}\" in
         your organization."
+  
+  controllers:
+    application_controller:
+      errors:
+        current_user_admin:
+          "You are not permitted to view that page"
+        authenticate_user:
+          "You need to sign in for access to this page"
+    auth_controller:
+      successes:
+        oauth_callback: "You successfully signed in"
+    employees_controller:
+      notices:
+        create: "Thanks for adding %{slack_username}"
+        update: "Employee updated successfully"
+        destroy: "You deleted %{slack_username}"
+    messages_controller:
+      notices:
+        create: "Message created successfully"
+    scheduled_messages_controller:
+      notices:
+        create: "Scheduled message created successfully"
+        update: "Scheduled message updated successfully"
+        destroy: "You deleted %{scheduled_message_title}"
+      errors:
+        create: "Could not create scheduled message"
+        update: "Could not update scheduled message"
+    send_messages_controller:
+      notices:
+        create: "Message sent to all users"
+    test_messages_controller:
+      notices:
+        create: "Test message sent successfully"
+      errors:
+        create:
+          employee_nil: 
+            "Oops! Looks like that employee isn't in the Dolores system yet! Make sure you've entered the Slack handle (%{slack_username}) 
+            for the employee before sending him/her/them a test message."
+          not_up_to_date:
+            "Oops! Looks like this employees information isn't up to date. Check to make sure they haven't changed their slackname!"
+    users_controller:
+      notices:
+        update: "User updated successfully"
+
+
+
+
+
 


### PR DESCRIPTION
Fixes issue(s) # .

Changes proposed in this pull request:

this address issue #194 

- moved flash messages over to I18n
      * organized as controllers -> specific_controller -> flash msg. type -> controller action

/cc relevant people

