### PR TITLE
Add "Forbidden" page for unsuccessful auth

### DIFF
--- a/app/controllers/auth_controller.rb
+++ b/app/controllers/auth_controller.rb
@@ -7,6 +7,8 @@ class AuthController < ApplicationController
       sign_in(user)
       flash[:success] = I18n.t('controllers.auth_controller.successes.oauth_callback')
       redirect_to root_path
+    else
+      render :forbidden
     end
   end
 

--- a/app/views/auth/forbidden.html.erb
+++ b/app/views/auth/forbidden.html.erb
@@ -1,0 +1,17 @@
+<section class="main-content">
+  <h1>Forbidden</h1>
+  <p>
+    We were unable to authenticate your user profile.
+  </p>
+  <p>
+    If you are signing in via GitHub, please verify that you are a member of the
+    appropriate GitHub organization and that your
+    <%=
+      link_to "membership is public",
+        "https://help.github.com/articles/publicizing-or-hiding-organization-membership/"
+    %>.
+  <p/>
+  <p>
+    <%= link_to "Try to sign in with GitHub again", "/auth/githubteammember" %>
+  </p>
+</section>

--- a/spec/features/sign_in_user_spec.rb
+++ b/spec/features/sign_in_user_spec.rb
@@ -1,0 +1,41 @@
+require "rails_helper"
+
+feature "Sign in user" do
+  scenario "signing in a new user that is a member of the correct Github team" do
+    setup_mock_auth("user@example.com")
+
+    visit root_path
+    click_link "Sign in with GitHub"
+
+    expect(page).to have_content "You successfully signed in"
+  end
+
+  scenario "attempting to sign in a new user that is not a member of the Github team and encountering an error" do
+    setup_mock_auth("user@example.com", team_member: false)
+
+    visit root_path
+    click_link "Sign in with GitHub"
+
+    expect(page).to have_content "We were unable to authenticate your user profile"
+  end
+
+  scenario "signing in an existing user that is a member of the correct Github team" do
+    user = create(:user)
+    setup_mock_auth(user.email)
+
+    visit root_path
+    click_link "Sign in with GitHub"
+
+    expect(page).to have_content "You successfully signed in"
+  end
+
+  scenario "signing in an existing user that has been removed from the correct Github team" do
+    user = create(:user)
+    setup_mock_auth(user.email, team_member: false)
+
+    visit root_path
+    click_link "Sign in with GitHub"
+
+    expect(page).to have_content "We were unable to authenticate your user profile"
+  end
+end

--- a/spec/support/oauth_helper.rb
+++ b/spec/support/oauth_helper.rb
@@ -4,11 +4,11 @@ module OauthHelper
     visit "/auth/githubteammember"
   end
 
-  def setup_mock_auth(email = "test@example.com")
+  def setup_mock_auth(email = "test@example.com", options = {})
     OmniAuth.config.mock_auth[:githubteammember] =
       OmniAuth::AuthHash.new(
         credentials: {
-          "team_member?" => true,
+          "team_member?" => team_member?(options),
         },
         provider: "githubteammember",
         info: {
@@ -18,5 +18,15 @@ module OauthHelper
           uid: "12345",
         },
     )
+  end
+
+  private
+
+  def team_member?(options)
+    if options[:team_member].nil?
+      true
+    else
+      options[:team_member]
+    end
   end
 end


### PR DESCRIPTION
Fixes issue(s) # 213

Changes proposed in this pull request:

- Add error page that is displayed after unsuccessful sign in

This commit adds a page that is displayed when the user attempts to authenticate and fails.

The page provides some hints about where to look to determine what could be causing the problem.
Additionally it provides a link to attempt another sign in.

Originally I was going to render the new session view with a flash message, but decided on a separate page since it provides more information about what might have gone wrong.