### PR TITLE
Remove `--deployment` from travis's bundler options

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 before_script:
 - cp .sample.env .env
 - bin/rake db:setup --trace
-bundler_args: "--deployment --jobs=3 --retry=3 --without development"
+bundler_args: "--jobs=3 --retry=3 --without development"
 cache: bundler
 before_deploy:
   - export PATH=$HOME:$PATH


### PR DESCRIPTION
Changes proposed in this pull request:

- Remove `--deployment` from travis's bundler options

Bundler's `--deployment` flag causes gems to be installed in `vendor/bundle`. This causes problems with automated deploys since some of these files have a mode < 600.