### PR TITLE
Temporarily disable quarterly messages

### DIFF
--- a/app/assets/stylesheets/components/_alert.scss
+++ b/app/assets/stylesheets/components/_alert.scss
@@ -4,7 +4,6 @@
   background-color: #d0e9c6;
   font-size: 0.8rem;
   padding: 0.5em;
-  @include span-columns(10);
   border-radius:0.5em;
   margin-bottom: 1em;
 }

--- a/app/views/layouts/_sidenav_items.html.erb
+++ b/app/views/layouts/_sidenav_items.html.erb
@@ -13,7 +13,8 @@
 </li>
 <li class="sidenav-list-item">
   <button class="sidenav-list_title" aria-expanded="<%= is_current(quarterly_messages_path) -%>" aria-controls="collapsible-2">
-    Quarterly messages
+    Quarterly messages <br/>
+    <small>Temporarily Disabled</small>
     <icon class="icon-circle-plus"></icon>
     <icon class="icon-circle-minus"></icon>
   </button>

--- a/app/views/quarterly_messages/_disabled_alert.html.erb
+++ b/app/views/quarterly_messages/_disabled_alert.html.erb
@@ -1,0 +1,5 @@
+<div class="alert">
+  Quarterly messages are temporiarily disabled.
+  You can still create, edit, delete and test querterly messages,
+  but they will not be sent at the start of a new quarter.
+</div>

--- a/app/views/quarterly_messages/edit.html.erb
+++ b/app/views/quarterly_messages/edit.html.erb
@@ -2,5 +2,6 @@
 
 <section class="main-content">
 	<%= render "flashes" -%>
+  <%= render "disabled_alert" %>
 	<%= render "form" %>
 </section>

--- a/app/views/quarterly_messages/index.html.erb
+++ b/app/views/quarterly_messages/index.html.erb
@@ -12,6 +12,7 @@
 
 <section class="main-content">
   <%= render "flashes" -%>
+  <%= render "disabled_alert" %>
   <table>
     <tr>
       <th>Title</th>

--- a/app/views/quarterly_messages/new.html.erb
+++ b/app/views/quarterly_messages/new.html.erb
@@ -2,5 +2,6 @@
 
 <section class="main-content">
 	<%= render "flashes" -%>
+  <%= render "disabled_alert" %>
 	<%= render "form" %>
 </section>

--- a/config/clock.rb
+++ b/config/clock.rb
@@ -8,10 +8,10 @@ module Clockwork
     OnboardingMessageSender.new.delay.run
   end
 
-  every(1.hour, "quarterly_messages.send") do
-    puts "Sending quarterly messages"
-    QuarterlyMessageSender.new.delay.run
-  end
+  # every(1.hour, "quarterly_messages.send") do
+  #   puts "Sending quarterly messages"
+  #   QuarterlyMessageSender.new.delay.run
+  # end
 
   every(1.day, "employees.import", at: "03:00", tz: "UTC") do
     puts "Importing new employees"


### PR DESCRIPTION
Changes proposed in this pull request:

- Comment out quarterly message code in clockwork config
- Add notice about quarterly messages being disabled to views

This temporarily disables quarterly messages to prevent confusion / miscommunication until we move forward on #234.