### PR TITLE
Fix TestCase HTTP related deprecation warnings

### DIFF
--- a/spec/controllers/broadcast_messages_controller_spec.rb
+++ b/spec/controllers/broadcast_messages_controller_spec.rb
@@ -18,7 +18,9 @@ describe BroadcastMessagesController do
       user = create(:user, admin: false)
       allow(controller).to receive(:current_user).and_return(user)
 
-      post :create, broadcast_message: { title: "t", body: "b" }
+      process :create, method: :post, params: {
+        broadcast_message: { title: "t", body: "b" }
+      }
 
       expect(response).to redirect_to root_path
       expect(flash[:error]).to be_present

--- a/spec/controllers/send_messages_controller_spec.rb
+++ b/spec/controllers/send_messages_controller_spec.rb
@@ -6,7 +6,7 @@ describe SendBroadcastMessagesController do
       user = create(:user, admin: false)
       allow(controller).to receive(:current_user).and_return(user)
 
-      post :create, broadcast_message_id: 1
+      process :create, method: :post, params: { broadcast_message_id: 1 }
 
       expect(response).to redirect_to root_path
       expect(flash[:error]).to be_present


### PR DESCRIPTION
Fixes issue(s) #228.

Changes proposed in this pull request:

- Fixes TestCase HTTP methods deprecation warning

/cc @jessieay.