### PR TITLE
Deploy to govcloud

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,13 +5,15 @@ bundler_args: "--jobs=3 --retry=3 --without development"
 cache: bundler
 before_deploy:
   - export PATH=$HOME:$PATH
-  - travis_retry curl -L -o $HOME/cf.tgz "https://cli.run.pivotal.io/stable?release=linux64-binary&version=6.15.0"
+  - travis_retry curl -L -o $HOME/cf.tgz "https://cli.run.pivotal.io/stable?release=linux64-binary&version=6.24.0"
   - tar xzvf $HOME/cf.tgz -C $HOME
 env:
   global:
   - DB=postgresql
-  - CF_USERNAME=18f-dolores-deployer
-  - secure: AJwrGkiXOnUIXORLLnFITHAPK4djtY0dvQRYRTlmSJD8hq3/AUMhmhhFRVlSB5cje7Mp4Sm9ChiUBoB029tj1nSGZZGCAEoVdlv1/wwHMAlS3Cou/O+AhxQTEg75wFNxNJArYPyqjXQxETRLKBv19z28EUADEZ+x3EHb4KNvnD5PL/tXn4snFh090w0BYbzkx1vHBURajuxeSPYT46kz+gZeU/ogZ9Ur3sFzHJjDJkS0EgicYIm13GrLokXv7mDbZa26OKRc5Sh0X19xHuPMl5USmXXNF+avQaaf0bEq84GIwjiYdGPfQP2MF/MX8U5FSxjWCOLYQGY/qZSgzj4jjEhxXtzCA55hPRinIh/PyJnQ8qeTB5FhJNU9JhTnGB9EaWDpfF1q23oQ6SeHRgUiqUJU3Vqxamlcdg7kuwh8syabgGflb8kpmQLUPC3AsyOMM0OG9ZxrbxgLf3SEg6x+fDQI8EOfg8cKNSGpu6FZIzVgVvCurG7CnrjnH8fDht+3GVx7J0F48/pXujcfgQcQ+L3eOF6NywmeNr8qccYcthbHKS3g8fUPVfHqpUlFpw/tQfEjdlFUktbSeuqW09xXsuOEbsZVQktVS9wwYYBbVVosbcKPDF5yAk7R9YuhnlZ0LLlJ5etDAHnI8HAMmhAQy27LnmJNTRkcbg0wj86ESZg=
+  - CF_USERNAME_PRODUCTION=95a52758-4a02-460b-9942-54d552b298b8
+  - secure: "ceP4d1q5Kac7wpnLu9Oee1TmJEVFoICJdgsSbzA3R4y5neVO3djn1UwH7N3lScaOYgXJTocyrUpLjxx0ILWdyIwFrMo9ClgzNynd9hyOBWxKpkFD9ZW7+L7G71IPg3wHZJSxVwLix1bXoRbhoJhHcJTkg4jr5nCHVYyw1mLUL3ah/ltsHGm64ehtRzjhFIKow5iPRuvO/7+u5g8mjL+3+BzSH4VDyP1hZnpY0cWE79zRwHL6+Fgxsfp11iqy/yGDFLUCdg0yn8mx7B+ULWOrEs3CyCJXr0oZn4GCca7Ywj5V6w+yy2FuLGlDZBElp5FXFHMxCc2tzEFQ+qFDYOiAfNksb+2vk86RSrdiiypWvh/EE4sIEZs91BMgGrTNVRifQNM0HU2Is2jKqcyM1zoh+1F/9pOPx2bbyx+ro9wi+aj+EbUns80KHEzmzQ4yP4j8ZczC1iZdVl6HH82t1uZ2as8ezeG5figw+H1ojEM2mNd8WicoeGkH8/HabPDrskkksg6Q3nNxmrl97COLCrOQ6FpskF+4F6ABCxIvw5yMzgAlz7RwwAliqxw1I8/6+wa19QQ/TXotnB15lB+Dy//Yt3RWmxv67t89aTkfO7wwRs/PAgZg4q/r/trkOj5r6fW9cnZg1V7c90VWXmCdJ65yfZz5RKbcx0ccniw+a8oqCD0="
+  - CF_USERNAME_STAGING=a31c1a7d-6929-48d4-9edf-be2a805a5c7e
+  - secure: "dM+XWHIKL/lkm3edTGCY81hyFlTMJUNZqanGCfFLuONBdeMAwql6shRBL4DsQeDGRA9wL4BByUAObqCTtnmfFQaAu99ONC4V8j0UdvIfirNjdTX1OK7Q2ovzjxNs1EY/ui4TNzTmnGSeO4QPKFPWI+7YVgjAPkYZsY3tK6dMSk7il+GeXTN3u2D7rhT5VtYym/4AJFZmPjtGDotiuSfoA/FpFdaK2dNcZDxAmtA1g9LirWMExwd0VDfI4pGLROUX45KtugU/3ExOxQ9Esdsv1nzoMRmaXrqWZ4gWufoVErUMs5UI6g18h6bb6KNnRN36o59GttevkK8y56nshbeuTcHSMnSjSbjrX6vvfWXiDEiBcsuJAYWV1yMTbGpBZ+KkYfZm5PXSKmZwOQ1bWd7FHURA3gL4EtWBxo9qq4gBMYmbZmtTJF4dsCD9+htFXg8j11cQUE7S1X8oJJgty31uQuDCk403zIeN6TE6ByDJUyiaZ4m/DFvdcIlrHSZgPOEqY0nXdoxby8DN7r8sAgiv3WrFd9unMcU86uvVzogOZhheMv/FPGqVM5WJe3aS0o/4z47AVLOrLLcFRZCKq3/wc8evXWk6/Tv5kbssOiS0bKwV/ClKBC/eXHaGcvd/h1at1tH5g1z3a9QSjeAUpqgCJ4ChcSOpoDOvC704x45SmD8="
 language: ruby
 rvm:
 - ruby-2.3.3
@@ -25,7 +27,7 @@ deploy:
   on:
     branch: develop
 - provider: script
-  script: "./bin/deploy.sh production"
+  script: "./bin/deploy.sh prod"
   skip_cleanup: true
   on:
     branch: master

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -219,27 +219,44 @@ Cloud Foundry by an 18f-er.
 Refer to [docs.cloud.gov](https://docs.cloud.gov/getting-started/setup/) for
 getting set up with Cloud Foundry.
 
-The Dolores Landingham bot is deployed within the `18f` Cloud Foundry org. To
-see if you have access to the `18f` do the following in the root of your repo:
+The Dolores Landingham bot is deployed within the `gsa-18f-dolores` Cloud Foundry org. To
+see if you have access to the `gsa-18f-dolores` do the following in the root of your repo:
 
 `cf orgs`
 
-If `18f` does not show up as an available org, you can request access by asking a
-space-manager to [invite you](https://docs.cloud.gov/apps/managing-teammates/).
+If `gsa-18f-dolores` does not show up as an available org, you can request access by asking a
+org-manager to [invite you as a `SpaceDeveloper`](https://docs.cloud.gov/apps/managing-teammates/) to
+the `prod` and `staging` spaces of that org.
 
 Once you have access to the org, you can target the Cloud Foundry organization
 and space for this project:
 
-`cf target -o 18f -s dolores`
+```bash
+# To target the production space
+cf target -o gsa-18f-dolores -s prod
+
+# To target the staging space
+cf target -o gsa-18f-dolores -s staging
+```
 
 Once your target is set, you can push the application. We have two Cloud Foundry
 instances: `dolores-app` and `dolores-staging`. Test your changes by pushing to
-`dolores-staging` before pushing to the `dolores-app` instance.
+`dolores-staging` in the `staging` space before pushing to the `dolores-app`
+instance to the `prod` space.
 
-`cf push <app-instance-name>`
+```bash
+# Pushing the production app while targeting the "prod" space.
+cf push -f manifest.yml
 
-New migrations will be run automatically. See the [manifest](manifest.yml) for
+# Pushing the staging app while targeting the "staging" space.
+cf push -f manifest_staging.yml
+```
+
+New migrations will be run automatically. See the manifest files for
 more details on the Cloud Foundry setup.
+- [Production manifest](manifest.yml)
+- [Staging manifest](manifest_staging.yml)
+- [Base manifest](manifest_base.yml)
 
 To see existing environment variables:
 
@@ -248,3 +265,9 @@ To see existing environment variables:
 To set or change the value of an environment variable:
 
 `cf set-env <app-instance-name> <env-name> <env-value>`
+
+You may have to set these environment variables manually as they contain secrets.
+- `GITHUB_CLIENT_ID`
+- `GITHUB_CLIENT_SECRET`
+- `GITHUB_TEAM_ID`
+- `SLACK_API_TOKEN`

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -1,18 +1,23 @@
 set -e
 
-API="https://api.cloud.gov"
-ORG="18f"
-SPACE="dolores"
-ENVIRONMENT=$1
+API="https://api.fr.cloud.gov"
+ORG="gsa-18f-dolores"
+SPACE=$1
 
-if [ $ENVIRONMENT = 'production' ]; then
+if [ $SPACE = 'prod' ]; then
   NAME="dolores-app"
-elif [ $ENVIRONMENT = 'staging' ]; then
+  CF_USERNAME=$CF_USERNAME_PRODUCTION
+  CF_PASSWORD=$CF_PASSWORD_PRODUCTION
+  MANIFEST="manifest.yml"
+elif [ $SPACE = 'staging' ]; then
   NAME="dolores-staging"
+  CF_USERNAME=$CF_USERNAME_STAGING
+  CF_PASSWORD=$CF_PASSWORD_STAGING
+  MANIFEST="manifest_staging.yml"
 else
-  echo "Unknown environment: $ENVIRONMENT"
+  echo "Unknown space: $SPACE"
   exit
 fi
 
-cf login --a $API --u $CF_USERNAME --p $CF_PASSWORD --o $ORG -s $SPACE
-cf push $NAME
+cf login -a $API -u $CF_USERNAME -p $CF_PASSWORD -o $ORG -s $SPACE
+cf push -f $MANIFEST

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,5 +1,6 @@
 # based on https://github.com/18F/C2/blob/master/manifest.yml
-domain: 18f.gov
+# domain: 18f.gov
+# ^ Temporarily commented out. This fails with 'Domain not found'. –@fureigh
 command: script/start
 
   # environment-specific configuration

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,31 +1,13 @@
-# based on https://github.com/18F/C2/blob/master/manifest.yml
-# domain: 18f.gov
-# ^ Temporarily commented out. This fails with 'Domain not found'. –@fureigh
-command: script/start
-
-  # environment-specific configuration
+# production environment-specific configuration
+inherit: manifest_base.yml
+no-hostname: true
 applications:
 - name: dolores-app
-  buildpack: https://github.com/cloudfoundry/ruby-buildpack.git
-  memory: 1GB
+  domains:
+    - dolores-app.18f.gov
   env:
     DEFAULT_URL_HOST: dolores-app.18f.gov
     HOST: dolores-app.18f.gov
     APPLICATION_HOST: dolores-app.18f.gov
-    RESTRICT_ACCESS: true
-    RACK_ENV: production
-    RAILS_ENV: production
   services:
     - dolores-app-db
-- name: dolores-staging
-  buildpack: https://github.com/cloudfoundry/ruby-buildpack.git
-  memory: 1GB
-  env:
-    DEFAULT_URL_HOST: dolores-staging.18f.gov
-    HOST: dolores-staging.18f.gov
-    APPLICATION_HOST: dolores-staging.18f.gov
-    RESTRICT_ACCESS: true
-    RACK_ENV: production
-    RAILS_ENV: production
-  services:
-    - dolores-staging-db

--- a/manifest_base.yml
+++ b/manifest_base.yml
@@ -2,7 +2,7 @@
 ---
 command: script/start
 memory: 1GB
-buildpack: https://github.com/cloudfoundry/ruby-buildpack.git
+buildpack: ruby_buildpack
 env:
   RESTRICT_ACCESS: true
   RACK_ENV: production

--- a/manifest_base.yml
+++ b/manifest_base.yml
@@ -1,0 +1,9 @@
+# base configuration
+---
+command: script/start
+memory: 1GB
+buildpack: https://github.com/cloudfoundry/ruby-buildpack.git
+env:
+  RESTRICT_ACCESS: true
+  RACK_ENV: production
+  RAILS_ENV: production

--- a/manifest_staging.yml
+++ b/manifest_staging.yml
@@ -1,0 +1,10 @@
+# staging environment-specific configuration
+inherit: manifest_base.yml
+applications:
+- name: dolores-staging
+  env:
+    DEFAULT_URL_HOST: dolores-staging.18f.gov
+    HOST: dolores-staging.18f.gov
+    APPLICATION_HOST: dolores-staging.18f.gov
+  services:
+    - dolores-staging-db

--- a/manifest_staging.yml
+++ b/manifest_staging.yml
@@ -1,7 +1,10 @@
 # staging environment-specific configuration
 inherit: manifest_base.yml
+no-hostname: true
 applications:
 - name: dolores-staging
+  domains:
+    - dolores-staging.18f.gov
   env:
     DEFAULT_URL_HOST: dolores-staging.18f.gov
     HOST: dolores-staging.18f.gov


### PR DESCRIPTION
Fixes issue(s) # https://github.com/18F/cg-migration/issues/37 Migrate to GovCloud.

Changes proposed in this pull request:

- Use two sets of deployer credentials. one for prod and one for staging via deployer account broker
- update cf cli 
- update manifest to use whole domain `dolores-app.18f.gov` vs the domain `18f.gov` with hostname `dolores-app`

/cc cc @fureigh @jessieay 

