### PR TITLE
Remove Employee uniqueness validation from SentMessage

### DIFF
--- a/app/models/sent_message.rb
+++ b/app/models/sent_message.rb
@@ -4,9 +4,7 @@ class SentMessage < ActiveRecord::Base
   belongs_to :employee
   belongs_to :message, polymorphic: true
 
-  validates :employee, presence: true, uniqueness: {
-    scope: [:message_id, :message_type],
-  }
+  validates :employee, presence: true
   validates :message_body, presence: true
   validates :message, presence: true
   validates :sent_at, presence: true

--- a/db/migrate/20170310195553_remove_sent_message_employee_uniqueness_constraint.rb
+++ b/db/migrate/20170310195553_remove_sent_message_employee_uniqueness_constraint.rb
@@ -1,0 +1,14 @@
+class RemoveSentMessageEmployeeUniquenessConstraint < ActiveRecord::Migration[5.0]
+  def up
+    remove_index(:sent_messages, name: "by_employee_message")
+  end
+
+  def down
+    add_index(
+      :sent_messages,
+      [:employee_id, :message_id, :message_type],
+      unique: true,
+      name: "by_employee_message",
+    )
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160920181736) do
+ActiveRecord::Schema.define(version: 20170310195553) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -84,7 +84,6 @@ ActiveRecord::Schema.define(version: 20160920181736) do
     t.datetime "deleted_at"
     t.string   "message_type",                                  null: false
     t.index ["deleted_at"], name: "index_sent_messages_on_deleted_at", using: :btree
-    t.index ["employee_id", "message_id", "message_type"], name: "by_employee_message", unique: true, using: :btree
   end
 
   create_table "taggings", force: :cascade do |t|

--- a/spec/models/sent_message_spec.rb
+++ b/spec/models/sent_message_spec.rb
@@ -12,24 +12,6 @@ describe SentMessage do
     it { should validate_presence_of(:message) }
     it { should validate_presence_of(:sent_at) }
     it { should validate_presence_of(:sent_on) }
-
-    it "validates employee uniqueness scoped to message" do
-      employee = build_stubbed(:employee)
-      message = build_stubbed(:onboarding_message)
-      create(
-        :sent_message,
-        employee: employee,
-        message: message,
-      )
-
-      duplicate_sent_scheduled_message = build(
-        :sent_message,
-        employee: employee,
-        message: message,
-      )
-
-      expect(duplicate_sent_scheduled_message).not_to be_valid
-    end
   end
 
   describe "Delegated methods" do


### PR DESCRIPTION
Fixes issue(s) # 250

Changes proposed in this pull request:

- Remove Employee uniqueness validation from SentMessage

The SentMessage model had a uniqueness validation scoped to the message. The effect of this validation is that a SentMessage can only be created once for a given message and employee. As a result, sending a message to an employee twice resulted in a failure to create a SentMessage record for the second message.

This commit fixes the above bug by removing the validation.

A byproduct of this change is that if an employee has been sent an onboarding message as part of a test before they were supposed to receive that message, they will not receive it at the scheduled time. This does not seem like a major concern since the employee will have ultimately still received the message.

Another byproduct is that an employee that has been sent a test quarterly message within a week of the beginning of a new quarter will not receive the message at the start of the new quarter. This does not seems like a concern since the employee will ultimately still receive receive the message near the beginning of the new quarter.

Finally this fix makes the assumption that there is not a reason to avoid creating SentMessage records for test messages. I am not aware of one, but if one exists, a follow up commit may be needed to tell the MessageSender not to create a SentMessage record for test messages. I think the fix on this commit still applies in that case, since we will still want to keep a record of when non-test messages get sent, even if they are sent twice for some reason.


/cc @jessieay 
