### PR TITLE
Don't create SentMessage records for test messages

### DIFF
--- a/app/controllers/test_messages_controller.rb
+++ b/app/controllers/test_messages_controller.rb
@@ -14,7 +14,7 @@ class TestMessagesController < ApplicationController
     employee = Employee.find_by(slack_username: slack_username)
 
     if employee && (employee.slack_channel_id || employee.slack_user_id)
-      MessageSender.new(employee, message).delay.run
+      MessageSender.new(employee, message, test_message: true).delay.run
       flash[:notice] = I18n.t('controllers.test_messages_controller.notices.create')
     elsif employee.nil?
       flash[:error] = I18n.t('controllers.test_messages_controller.errors.create.employee_nil', slack_username: slack_username)

--- a/app/services/message_sender.rb
+++ b/app/services/message_sender.rb
@@ -1,9 +1,10 @@
 require "slack-ruby-client"
 
 class MessageSender
-  def initialize(employee, message)
+  def initialize(employee, message, test_message: false)
     @employee = employee
     @message = message
+    @test_message = test_message
   end
 
   def run
@@ -47,7 +48,7 @@ class MessageSender
 
   private
 
-  attr_reader :employee, :message
+  attr_reader :employee, :message, :test_message
 
   def client
     @client ||= Slack::Web::Client.new
@@ -62,14 +63,16 @@ class MessageSender
   end
 
   def create_sent_message(options)
-    SentMessage.create(
-      employee: options[:employee],
-      message: options[:message],
-      sent_on: Date.current,
-      sent_at: Time.current,
-      error_message: error_message(options[:error]),
-      message_body: formatted_message(options),
-    )
+    if !test_message
+      SentMessage.create(
+        employee: options[:employee],
+        message: options[:message],
+        sent_on: Date.current,
+        sent_at: Time.current,
+        error_message: error_message(options[:error]),
+        message_body: formatted_message(options),
+      )
+    end
   end
 
   def error_message(error)

--- a/spec/features/send_onboarding_message_after_test_message_spec.rb
+++ b/spec/features/send_onboarding_message_after_test_message_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+
+feature "Send an oboarding message after a test message" do
+  scenario "Receiving a test message should not prevent a user from receiving the same scheduled onboarding message" do
+    days_after_start = 3
+    start_time = Time.parse("11:00:00 UTC")
+    employee_time_zone = "Eastern Time (US & Canada)"
+    current_time_for_employee = start_time.in_time_zone(employee_time_zone)
+    current_time_et_as_utc = Time.zone.utc_to_local(current_time_for_employee)
+    message_send_time = days_after_start.business_days.after start_time
+
+    onboarding_message = create(
+      :onboarding_message,
+      days_after_start: days_after_start,
+      time_of_day: current_time_et_as_utc
+    )
+    employee = create(:employee, started_on: start_time)
+
+    Timecop.freeze(start_time) do
+      send_test_onboarding_message(employee, onboarding_message)
+
+      Timecop.travel(days_after_start.business_days.after start_time)
+
+      expect { OnboardingMessageSender.new.run }.to change{ employee.sent_messages.count }.from(0).to(1)
+    end
+  end
+
+  def send_test_onboarding_message(employee, onboarding_message)
+    admin = create(:admin)
+    login_with_oauth(admin)
+    visit root_path
+    visit new_onboarding_message_test_message_path(onboarding_message)
+    fill_in :test_message_slack_username, with: employee.slack_username
+    click_on "Send test"
+  end
+end

--- a/spec/services/message_sender_spec.rb
+++ b/spec/services/message_sender_spec.rb
@@ -25,6 +25,16 @@ RSpec.shared_examples :message_sender do |message_type|
     Timecop.return
   end
 
+  it "doesn't create a sent message if the test_message option is true" do
+    employee = create(:employee)
+    mock_slack_channel_finder_for_employee(employee, channel_id: "fake_slack_channel_id")
+
+    allow(SentMessage).to receive(:create)
+
+    MessageSender.new(employee, message, test_message: true).run
+    expect(SentMessage).not_to have_received(:create)
+  end
+
   it 'presists the channel id to the employee\'s slack_channel_id field if sent successfully' do
     Timecop.freeze(Time.parse("10:00:00 UTC"))
 


### PR DESCRIPTION
Fixes issue(s) #250

Changes proposed in this pull request:

- Don't create SentMessage records for test messages
- Add a feature spec to make sure sending a user a test message does not prevent them from receiving it as a scheduled onboarding message.
